### PR TITLE
Option to store buffer data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Current version: **1.0.x** [![Build Status](https://api.travis-ci.org/hapijs/cat
   cached. Once this limit is reached no additional items will be added to the cache
   until some expire. The utilized memory calculation is a rough approximation and must
   not be relied on. Defaults to `104857600` (100MB).
+- `allowMixedContent` - stores and retrieves buffers as Buffer. Buffers are copied before storing to prevent value from changing while in the cache. Defaults to `false`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,19 +9,22 @@ var internals = {};
 
 
 internals.defaults = {
-    maxByteSize: 100 * 1024 * 1024          // 100MB
+    maxByteSize: 100 * 1024 * 1024,          // 100MB
+    allowMixedContent: false
 };
 
 // Provides a named reference for memory debugging
 internals.MemoryCacheSegment = function MemoryCacheSegment () {
 };
 
-internals.MemoryCacheEntry = function MemoryCacheEntry (key, value, ttl) {
+internals.MemoryCacheEntry = function MemoryCacheEntry (key, value, ttl, allowMixedContent) {
 
-    var valueIsBuffer = Buffer.isBuffer(value);
+    var storeAsBuffer = allowMixedContent && Buffer.isBuffer(value);
 
-    if (valueIsBuffer) {
-        this.item = value;
+    if (storeAsBuffer) {
+        this.item = new Buffer(value.length);
+        // copy buffer to prevent value from changing while in the cache
+        value.copy(this.item);
     } else {
         // stringify() to prevent value from changing while in the cache
         var stringifiedValue = JSON.stringify(value);
@@ -32,7 +35,7 @@ internals.MemoryCacheEntry = function MemoryCacheEntry (key, value, ttl) {
     this.ttl = ttl;
 
     // Approximate cache entry size without value: 144 bytes
-    this.byteSize = 144 + (valueIsBuffer ? value.size : Buffer.byteLength(stringifiedValue)) + Buffer.byteLength(key.segment) + Buffer.byteLength(key.id);
+    this.byteSize = 144 + (storeAsBuffer ? value.length : Buffer.byteLength(stringifiedValue)) + Buffer.byteLength(key.segment) + Buffer.byteLength(key.id);
 
     this.timeoutId = null;
 };
@@ -42,6 +45,7 @@ exports = module.exports = internals.Connection = function MemoryCache (options)
 
     Hoek.assert(this.constructor === internals.Connection, 'Memory cache client must be instantiated using new');
     Hoek.assert(!options || options.maxByteSize === undefined || options.maxByteSize >= 0, 'Invalid cache maxByteSize value');
+    Hoek.assert(!options || options.allowMixedContent === undefined || typeof options.allowMixedContent === 'boolean', 'Invalid allowMixedContent value');
 
     this.settings = Hoek.applyToDefaults(internals.defaults, options || {});
     this.cache = null;
@@ -145,7 +149,7 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
 
     var envelope = null;
     try {
-        envelope = new internals.MemoryCacheEntry(key, value, ttl);
+        envelope = new internals.MemoryCacheEntry(key, value, ttl, this.settings.allowMixedContent);
     } catch (err) {
         return callback(err);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -74,10 +74,51 @@ describe('Memory', function () {
         });
     });
 
-    it('gets a buffer item after setting it', function (done) {
+    it('gets a buffer item after setting it with allowMixedContent', function (done) {
 
         var buffer = new Buffer("I'm a string!", "utf-8");
-        var client = new Catbox.Client(new Memory());
+        var client = new Catbox.Client(new Memory({allowMixedContent: true}));
+
+        client.start(function (err) {
+
+            var key = { id: 'x', segment: 'test' };
+            client.set(key, buffer, 500, function (err) {
+
+                expect(err).to.not.exist;
+                client.get(key, function (err, result) {
+                    expect(err).to.equal(null);
+                    expect(result.item).to.deep.equal(buffer);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('stores a copy of the buffer when setting allowMixedContent', function (done) {
+
+        var buffer = new Buffer("I'm a string!", "utf-8");
+        var client = new Catbox.Client(new Memory({allowMixedContent: true}));
+
+        client.start(function (err) {
+
+            var key = { id: 'x', segment: 'test' };
+            client.set(key, buffer, 500, function (err) {
+
+                expect(err).to.not.exist;
+                client.get(key, function (err, result) {
+                    expect(err).to.equal(null);
+                    expect(result.item).to.not.equal(buffer);
+                    done();
+                });
+            });
+        });
+    });
+
+
+    it('returns a buffer as JSON when allowMixedContent is not set', function (done) {
+
+        var buffer = new Buffer("I'm a string!", "utf-8");
+        var client = new Catbox.Client(new Memory({}));
         client.start(function (err) {
 
             var key = { id: 'x', segment: 'test' };
@@ -87,7 +128,7 @@ describe('Memory', function () {
                 client.get(key, function (err, result) {
 
                     expect(err).to.equal(null);
-                    expect(result.item).to.equal(buffer);
+                    expect(result.item).to.deep.equal(JSON.parse(JSON.stringify(buffer)));
                     done();
                 });
             });


### PR DESCRIPTION
This pull request adds the option to store buffer data in catbox-memory.
With this option catbox-memory can be used to store pre-compressed data (ex gzip).
