### PR TITLE
Clean up timers when the cache is stopped.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,19 @@ internals.Connection.prototype.start = function (callback) {
 
 internals.Connection.prototype.stop = function () {
 
+    // Clean up pending eviction timers.
+    if (this.cache) {
+        var segments = Object.keys(this.cache);
+        for (var i = 0, il = segments.length; i < il; ++i) {
+            var segment = segments[i];
+            var keys = Object.keys(this.cache[segment]);
+            for (var j = 0, jl = keys.length; j < jl; ++j) {
+                var key = keys[j];
+                clearTimeout(this.cache[segment][key].timeoutId);
+            }
+        }
+    }
+
     this.cache = null;
     this.byteSize = 0;
     return;

--- a/test/index.js
+++ b/test/index.js
@@ -379,6 +379,40 @@ describe('Memory', function () {
         done();
     });
 
+    it('cleans up timers when stopped', { parallel: false }, function (done) {
+
+        var cleared;
+        var set;
+
+        var oldClear = clearTimeout;
+        clearTimeout = function (id) {
+            cleared = id;
+            return oldClear(id);
+        };
+
+        var oldSet = setTimeout;
+        setTimeout = function (fn, time) {
+            set = oldSet(fn, time);
+            return set;
+        };
+
+        var client = new Catbox.Client(Memory);
+        client.start(function (err) {
+
+            var key = { id: 'x', segment: 'test' };
+            client.set(key, '123', 500, function (err) {
+
+                client.stop();
+                clearTimeout = oldClear;
+                setTimeout = oldSet;
+                expect(err).to.not.exist();
+                expect(cleared).to.exist();
+                expect(cleared).to.equal(set);
+                done();
+            });
+        });
+    });
+
     describe('start()', function () {
 
         it('creates an empty cache object', function (done) {


### PR DESCRIPTION
Pending timers cause the Node process to remain running even after the rest of the program has completed. This change causes all pending timers to be cleared when the cache service is stopped.