### PR TITLE
Timer cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Current version: [![Current Version](https://img.shields.io/npm/v/catbox-memory.
   not be relied on. Defaults to `104857600` (100MB).
 - `allowMixedContent` - by default, all data is cached as JSON strings, and converted
   to an object using `JSON.parse()` on retrieval. By setting this option to `true`,
-  `Buffer` data can be stored alongside the stringified data. `Buffer`s are not 
+  `Buffer` data can be stored alongside the stringified data. `Buffer`s are not
   stringified, and are copied before storage to prevent the value from changing while
   in the cache. Defaults to `false`.
+- `intervalTime` - sets in milliseconds how often the cache gets checked to see if any
+  keys need to be expired. It will most likely not remove all expired keys in one
+  interval as only a small amount of keys are checked. If the key is expired and is
+  retrieved, it will not be returned by catbox as it is expired even if it still
+  exists in memory.
+- `numberOfKeysToCheck` - sets the sample size that will be checked. Any keys found
+  to be expired in that sample will be deleted. If enough keys are found to be deleted
+  then more keys will be checked.
+- `continueRatio` - sets the percentage of keys in the sample size that need to be
+  expired for the program to continue checking for more expired keys.

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,10 @@ var internals = {};
 
 internals.defaults = {
     maxByteSize: 100 * 1024 * 1024,          // 100MB
-    allowMixedContent: false
+    allowMixedContent: false,
+    intervalTime: 200,
+    numberOfKeysToCheck: 25,
+    continueRatio: 0.25
 };
 
 // Provides a named reference for memory debugging
@@ -23,11 +26,13 @@ internals.MemoryCacheEntry = function MemoryCacheEntry (key, value, ttl, allowMi
 
     if (allowMixedContent && Buffer.isBuffer(value)) {
         this.item = new Buffer(value.length);
+
         // copy buffer to prevent value from changing while in the cache
         value.copy(this.item);
         valueByteSize = this.item.length;
     }
     else {
+
         // stringify() to prevent value from changing while in the cache
         this.item = JSON.stringify(value);
         valueByteSize = Buffer.byteLength(this.item);
@@ -38,8 +43,6 @@ internals.MemoryCacheEntry = function MemoryCacheEntry (key, value, ttl, allowMi
 
     // Approximate cache entry size without value: 144 bytes
     this.byteSize = 144 + valueByteSize + Buffer.byteLength(key.segment) + Buffer.byteLength(key.id);
-
-    this.timeoutId = null;
 };
 
 
@@ -49,8 +52,15 @@ exports = module.exports = internals.Connection = function MemoryCache (options)
     Hoek.assert(!options || options.maxByteSize === undefined || options.maxByteSize >= 0, 'Invalid cache maxByteSize value');
     Hoek.assert(!options || options.allowMixedContent === undefined || typeof options.allowMixedContent === 'boolean', 'Invalid allowMixedContent value');
 
+    var self = this;
+
     this.settings = Hoek.applyToDefaults(internals.defaults, options || {});
     this.cache = null;
+
+    this.intervalId = setInterval(function () {
+
+        self._pruneCache(function () { });
+    }, this.settings.intervalTime);
 };
 
 
@@ -68,19 +78,6 @@ internals.Connection.prototype.start = function (callback) {
 
 
 internals.Connection.prototype.stop = function () {
-
-    // Clean up pending eviction timers.
-    if (this.cache) {
-        var segments = Object.keys(this.cache);
-        for (var i = 0, il = segments.length; i < il; ++i) {
-            var segment = segments[i];
-            var keys = Object.keys(this.cache[segment]);
-            for (var j = 0, jl = keys.length; j < jl; ++j) {
-                var key = keys[j];
-                clearTimeout(this.cache[segment][key].timeoutId);
-            }
-        }
-    }
 
     this.cache = null;
     this.byteSize = 0;
@@ -174,10 +171,7 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
     var segment = this.cache[key.segment];
 
     var cachedItem = segment[key.id];
-    if (cachedItem &&
-        cachedItem.timeoutId) {
-
-        clearTimeout(cachedItem.timeoutId);
+    if (cachedItem) {
         self.byteSize -= cachedItem.byteSize;                   // If the item existed, decrement the byteSize as the value could be different
     }
 
@@ -186,13 +180,6 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
             return callback(new Error('Cache size limit reached'));
         }
     }
-
-    var timeoutId = setTimeout(function () {
-
-        self.drop(key, function () { });
-    }, ttl);
-
-    envelope.timeoutId = timeoutId;
 
     segment[key.id] = envelope;
     this.byteSize += envelope.byteSize;
@@ -221,6 +208,83 @@ internals.Connection.prototype.drop = function (key, callback) {
     }
 
     return callback();
+};
+
+
+internals.Connection.prototype._pruneCache = function (callback) {
+
+    callback = Hoek.nextTick(callback);
+
+    if (!this.cache) {
+        return callback(new Error('Connection not started'));
+    }
+
+    // getOwnPropertyNames over keys for increased performance
+    // cache is properly created and has no extra properties but the cache items
+    var segments = Object.getOwnPropertyNames(this.cache);
+    for (var i = 0, il = segments.length; i < il; ++i) {
+
+        var segmentKey = segments[i];
+        var segment = this.cache[segmentKey];
+        this.byteSize -= internals.pruneKeys(segment, this.settings.numberOfKeysToCheck, this.settings.continueRatio);
+    }
+
+    return callback();
+};
+
+
+internals.pruneKeys = function (segment, numberOfKeysToCheck, continueRatio) {
+
+    var keysDeleted = 0;
+    var bytesDeleted = 0;
+    var generatedKeys = [];
+
+    var keys = Object.getOwnPropertyNames(segment);
+    var now = Date.now();
+
+    var checkAll = false;
+    if (keys.length <= numberOfKeysToCheck) {
+        checkAll = true;
+        numberOfKeysToCheck = keys.length;
+    }
+
+    for (var k = 0; k < numberOfKeysToCheck; ++k) {
+
+        var randomKeyIndex = k;
+        if (!checkAll) {
+            randomKeyIndex = internals.generateUniqueRandomIndex(keys.length, generatedKeys);
+        }
+
+        var keyId = keys[randomKeyIndex];
+        var item = segment[keyId];
+
+        var expires = item.stored + item.ttl;
+
+        if (expires - now <= 0) {
+            bytesDeleted += item.byteSize;
+            delete segment[keyId];
+            ++keysDeleted;
+        }
+    }
+
+    if (!checkAll && (keysDeleted / numberOfKeysToCheck >= continueRatio)) {
+        return bytesDeleted + internals.pruneKeys(segment, numberOfKeysToCheck - keysDeleted, continueRatio);
+    }
+
+    return bytesDeleted;
+};
+
+
+internals.generateUniqueRandomIndex = function (length, preGenerated) {
+
+    var random = Math.floor(Math.random() * length);
+    for (var i = 0; i < preGenerated.length; ++i) {
+        if ( preGenerated[i] === random ) {
+            return internals.generateUniqueRandomIndex(length, preGenerated);
+        }
+    }
+    preGenerated.push(random);
+    return random;
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -312,6 +312,25 @@ describe('Memory', function () {
         });
     });
 
+    it('empty response when using non-existent key', function (done) {
+
+        var client = new Catbox.Client(Memory);
+        client.start(function (err) {
+
+            var key = { id: 'x', segment: 'test' };
+            client.set(key, 'x', 1, function (err) {
+
+                expect(err).to.not.exist();
+                client.get({ id: 'bla', segment: 'test' }, function (err, result) {
+
+                    expect(err).to.be.null();
+                    expect(result).to.be.null();
+                    done();
+                });
+            });
+        });
+    });
+
     it('ignores set when using non-positive ttl value', function (done) {
 
         var client = new Catbox.Client(Memory);

--- a/test/index.js
+++ b/test/index.js
@@ -379,42 +379,6 @@ describe('Memory', function () {
         done();
     });
 
-    it('cleans up timers when stopped', { parallel: false }, function (done) {
-
-        var cleared;
-        var set;
-
-        var oldClear = clearTimeout;
-        clearTimeout = function (id) {
-
-            cleared = id;
-            return oldClear(id);
-        };
-
-        var oldSet = setTimeout;
-        setTimeout = function (fn, time) {
-
-            set = oldSet(fn, time);
-            return set;
-        };
-
-        var client = new Catbox.Client(Memory);
-        client.start(function (err) {
-
-            var key = { id: 'x', segment: 'test' };
-            client.set(key, '123', 500, function (err) {
-
-                client.stop();
-                clearTimeout = oldClear;
-                setTimeout = oldSet;
-                expect(err).to.not.exist();
-                expect(cleared).to.exist();
-                expect(cleared).to.equal(set);
-                done();
-            });
-        });
-    });
-
     describe('start()', function () {
 
         it('creates an empty cache object', function (done) {
@@ -526,7 +490,7 @@ describe('Memory', function () {
                 id: 'test'
             };
 
-            var memory = new Memory();
+            var memory = new Memory({ intervalTime: 5 });
             expect(memory.cache).to.not.exist();
 
             memory.start(function () {
@@ -539,7 +503,7 @@ describe('Memory', function () {
 
                         expect(memory.cache[key.segment][key.id]).to.not.exist();
                         done();
-                    }, 15);
+                    }, 25);
                 });
             });
         });
@@ -808,5 +772,53 @@ describe('Memory', function () {
             expect(result).to.equal(null);
             done();
         });
+    });
+
+    describe('_pruneCache()', function () {
+
+        it('errors when not connected', function (done) {
+
+            var memory = new Memory();
+            memory._pruneCache(function (err) {
+
+                expect(err).to.exist();
+                done();
+            });
+        });
+
+        it('has enough keys to do random check for pruning', function (done) {
+
+            var memory = new Memory({ intervalTime: 5, numberOfKeysToCheck: 10, continueRatio: 0.25 });
+            var cb = function (err) {
+
+                expect(err).to.not.exist();
+            };
+
+            memory.start(function () {
+
+                memory.set({ segment: 'seg1', id: 'nodelete' }, '123', 200, cb);
+                for (var i = 0; i < 20; i++) {
+                    memory.set({ segment: 'seg1', id: 'key' + i }, i, 20, cb);
+                    memory.set({ segment: 'seg2', id: 'clef' + i }, i, 20, cb);
+                    memory.set({ segment: 'seg3', id: 'schlüssel' + i }, i, 13, cb);
+                }
+                memory.set({ segment: 'seg1', id: 'nodelete2' }, '123', 500, cb);
+                memory.set({ segment: 'seg1', id: 'key20' }, '123', 20, cb);
+                memory.set({ segment: 'seg1', id: 'key21' }, '123', 20, cb);
+                memory.set({ segment: 'გასაღები', id: 'mykey' }, '123', 60, cb);
+
+                setTimeout(function () {
+
+                    expect(Object.keys(memory.cache.seg1).length).to.be.below(15);
+                    expect(Object.keys(memory.cache.seg1)).to.include('nodelete');
+                    expect(Object.keys(memory.cache.seg1)).to.include('nodelete2');
+                    expect(Object.keys(memory.cache.seg2).length).to.be.below(15);
+                    expect(Object.keys(memory.cache.seg3).length).to.be.below(15);
+                    expect(Object.keys(memory.cache['გასაღები']).length).to.equal(0);
+                    done();
+                }, 100);
+            });
+        });
+
     });
 });


### PR DESCRIPTION
… using setTimeout

This is in relations to Issue #8 
This PR is not ready to be merged. I have the following questions:
1) I don't really like the names of the options (numberOfKeysToCheck maybe could be sampleSize, ...)
2) I need to benchmark this with 100, 2000, 40000, 100000 keys and see the performance impact (hopefully better as key size increase and minimal impact in the low key size). Especially in terms of memory and how long the thread stays blocked. Might need to use process.nextTick in certain situations.
3) I copied http://redis.io/commands/EXPIRE#how-redis-expires-keys which I think seems a reasonable algorithm when a lot of in-memory caching is going on but then aren't we limited a lot in memory of node processes? I might have gone overboard.