### PR TITLE
Use big-time for long timeout support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 // Load modules
 
+var BigTime = require('big-time');
 var Hoek = require('hoek');
 
 
@@ -77,7 +78,7 @@ internals.Connection.prototype.stop = function () {
             var keys = Object.keys(this.cache[segment]);
             for (var j = 0, jl = keys.length; j < jl; ++j) {
                 var key = keys[j];
-                clearTimeout(this.cache[segment][key].timeoutId);
+                BigTime.clearTimeout(this.cache[segment][key].timeoutId);
             }
         }
     }
@@ -177,7 +178,7 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
     if (cachedItem &&
         cachedItem.timeoutId) {
 
-        clearTimeout(cachedItem.timeoutId);
+        BigTime.clearTimeout(cachedItem.timeoutId);
         self.byteSize -= cachedItem.byteSize;                   // If the item existed, decrement the byteSize as the value could be different
     }
 
@@ -187,7 +188,7 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
         }
     }
 
-    var timeoutId = setTimeout(function () {
+    var timeoutId = BigTime.setTimeout(function () {
 
         self.drop(key, function () { });
     }, ttl);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": ">=0.10.30"
   },
   "dependencies": {
+    "big-time": "1.x.x",
     "hoek": "2.x.x"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 // Load modules
 
+var BigTime = require('big-time');
 var Code = require('code');
 var Lab = require('lab');
 var Catbox = require('catbox');
@@ -158,10 +159,10 @@ describe('Memory', function () {
                     client.set(key, '345', 500, function (err) {
 
                         expect(err).to.not.exist();
-                        client.get(key, function (err, result) {
+                        client.get(key, function (err, value) {
 
                             expect(err).to.equal(null);
-                            expect(result.item).to.equal('345');
+                            expect(value.item).to.equal('345');
                             done();
                         });
                     });
@@ -384,15 +385,15 @@ describe('Memory', function () {
         var cleared;
         var set;
 
-        var oldClear = clearTimeout;
-        clearTimeout = function (id) {
+        var oldClear = BigTime.clearTimeout;
+        BigTime.clearTimeout = function (id) {
 
             cleared = id;
             return oldClear(id);
         };
 
-        var oldSet = setTimeout;
-        setTimeout = function (fn, time) {
+        var oldSet = BigTime.setTimeout;
+        BigTime.setTimeout = function (fn, time) {
 
             set = oldSet(fn, time);
             return set;
@@ -405,8 +406,8 @@ describe('Memory', function () {
             client.set(key, '123', 500, function (err) {
 
                 client.stop();
-                clearTimeout = oldClear;
-                setTimeout = oldSet;
+                BigTime.clearTimeout = oldClear;
+                BigTime.setTimeout = oldSet;
                 expect(err).to.not.exist();
                 expect(cleared).to.exist();
                 expect(cleared).to.equal(set);


### PR DESCRIPTION
`big-time` allows timeouts longer than what is supported natively by `setTimeout()` (thanks @arb).

Thoughts, @hueniverse? Mostly, would this cause any problems with catbox as a whole.