### PR TITLE
fix: cancel timeouts on drop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -215,6 +215,7 @@ internals.Connection.prototype.drop = function (key, callback) {
         const item = segment[key.id];
 
         if (item) {
+            clearTimeout(item.timeoutId);
             this.byteSize -= item.byteSize;
         }
 


### PR DESCRIPTION
Clear timeouts if the item is being dropped. Timers were hanging the process  in my tap tests.

ex:

```js
test('Something important', t => co(function * () {
    const id = 'an-id';
    const segment = 'segment';

    // assume promisified methods
    yield cache.set({id, segment }, 'useless value', 1440000);
    yield cache.drop({ id, segment });

    cache.stop();
    t.end();
    // timeout at this point
}));
```