### PR TITLE
Precision for unsupported cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ catbox-memory
 =============
 
 Memory adapter for [catbox](https://github.com/hapijs/catbox).
+This adapter is not designed to share a common cache between multiple processes (e.g. in a cluster mode).
 
 Lead Maintainer - [Wyatt Preul](https://github.com/geek)
 


### PR DESCRIPTION
Precision in the readme for the unsupported sharing of a common cache with multiple processes (cluster mode)