### PR TITLE
Use big-time for long timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,3 @@ Current version: [![Current Version](https://img.shields.io/npm/v/catbox-memory.
   `Buffer` data can be stored alongside the stringified data. `Buffer`s are not
   stringified, and are copied before storage to prevent the value from changing while
   in the cache. Defaults to `false`.
-
-Note: the maximum allowed value for `ttl` is `2^31-1`, which is around 24.8 days.

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 // Load modules
 
+const BigTime = require('big-time');
 const Hoek = require('hoek');
 
 
@@ -78,7 +79,7 @@ internals.Connection.prototype.stop = function () {
             const keys = Object.keys(this.cache[segment]);
             for (let j = 0; j < keys.length; ++j) {
                 const key = keys[j];
-                clearTimeout(this.cache[segment][key].timeoutId);
+                BigTime.clearTimeout(this.cache[segment][key].timeoutId);
             }
         }
     }
@@ -159,7 +160,7 @@ internals.Connection.prototype.set = async function (key, value, ttl) {
     const cachedItem = segment[key.id];
 
     if (cachedItem && cachedItem.timeoutId) {
-        clearTimeout(cachedItem.timeoutId);
+        BigTime.clearTimeout(cachedItem.timeoutId);
         this.byteSize -= cachedItem.byteSize;                   // If the item existed, decrement the byteSize as the value could be different
     }
 
@@ -169,7 +170,7 @@ internals.Connection.prototype.set = async function (key, value, ttl) {
         throw new Error('Cache size limit reached');
     }
 
-    envelope.timeoutId = setTimeout(() => this.drop(key), ttl);
+    envelope.timeoutId = BigTime.setTimeout(() => this.drop(key), ttl);
 
     segment[key.id] = envelope;
     this.byteSize += envelope.byteSize;
@@ -187,7 +188,7 @@ internals.Connection.prototype.drop = async function (key) {
         const item = segment[key.id];
 
         if (item) {
-            clearTimeout(item.timeoutId);
+            BigTime.clearTimeout(item.timeoutId);
             this.byteSize -= item.byteSize;
         }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
+    "big-time": "2.x.x",
     "hoek": "5.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
- Support timeouts longer than what is natively supported by Node.
- No extra dependencies (besides big-time itself)
- Node 6+, no build step or Babel