### PR TITLE
Implementation that does not require setTimeout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ internals.MemoryCacheEntry = function MemoryCacheEntry(key, value, ttl, allowMix
 
     this.stored = Date.now();
     this.ttl = ttl;
-    this.timeout = this.stored + ttl;
+    this.expireTime = this.stored + ttl;
 
     // Approximate cache entry size without value: 144 bytes
     this.byteSize = 144 + valueByteSize + Buffer.byteLength(key.segment) + Buffer.byteLength(key.id);
@@ -111,7 +111,7 @@ internals.Connection.prototype.get = async function (key) {
         return null;
     }
 
-    if (Date.now() > envelope.timeout) {
+    if (Date.now() > envelope.expireTime) {
         this.drop(key);
         return null;
     }
@@ -149,7 +149,7 @@ internals.Connection.prototype.set = async function (key, value, ttl) {
     const segment = this.cache[key.segment];
     const cachedItem = segment[key.id];
 
-    if (cachedItem && Date.now() < cachedItem.timeout) {
+    if (cachedItem && Date.now() < cachedItem.expireTime) {
         this.byteSize -= cachedItem.byteSize;                   // If the item existed, decrement the byteSize as the value could be different
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
 // Load modules
 
-const BigTime = require('big-time');
 const Hoek = require('hoek');
 
 
@@ -40,11 +39,11 @@ internals.MemoryCacheEntry = function MemoryCacheEntry(key, value, ttl, allowMix
 
     this.stored = Date.now();
     this.ttl = ttl;
+    this.timeout = this.stored + ttl;
 
     // Approximate cache entry size without value: 144 bytes
     this.byteSize = 144 + valueByteSize + Buffer.byteLength(key.segment) + Buffer.byteLength(key.id);
 
-    this.timeoutId = null;
 };
 
 
@@ -69,20 +68,6 @@ internals.Connection.prototype.start = async function () {
 
 
 internals.Connection.prototype.stop = function () {
-
-    // Clean up pending eviction timers
-
-    if (this.cache) {
-        const segments = Object.keys(this.cache);
-        for (let i = 0; i < segments.length; ++i) {
-            const segment = segments[i];
-            const keys = Object.keys(this.cache[segment]);
-            for (let j = 0; j < keys.length; ++j) {
-                const key = keys[j];
-                BigTime.clearTimeout(this.cache[segment][key].timeoutId);
-            }
-        }
-    }
 
     this.cache = null;
     this.byteSize = 0;
@@ -126,6 +111,11 @@ internals.Connection.prototype.get = async function (key) {
         return null;
     }
 
+    if (Date.now() > envelope.timeout) {
+        this.drop(key);
+        return null;
+    }
+
     let item = null;
     if (Buffer.isBuffer(envelope.item)) {
         item = envelope.item;
@@ -159,8 +149,7 @@ internals.Connection.prototype.set = async function (key, value, ttl) {
     const segment = this.cache[key.segment];
     const cachedItem = segment[key.id];
 
-    if (cachedItem && cachedItem.timeoutId) {
-        BigTime.clearTimeout(cachedItem.timeoutId);
+    if (cachedItem && Date.now() < cachedItem.timeout) {
         this.byteSize -= cachedItem.byteSize;                   // If the item existed, decrement the byteSize as the value could be different
     }
 
@@ -169,8 +158,6 @@ internals.Connection.prototype.set = async function (key, value, ttl) {
 
         throw new Error('Cache size limit reached');
     }
-
-    envelope.timeoutId = BigTime.setTimeout(() => this.drop(key), ttl);
 
     segment[key.id] = envelope;
     this.byteSize += envelope.byteSize;
@@ -188,7 +175,6 @@ internals.Connection.prototype.drop = async function (key) {
         const item = segment[key.id];
 
         if (item) {
-            BigTime.clearTimeout(item.timeoutId);
             this.byteSize -= item.byteSize;
         }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "big-time": "2.x.x",
     "hoek": "5.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This is more of a proof of concept than anything else, I'd like your input as to why this approach is not desirable and/or feasible.

We're interested in an approach that does not require setTimeout as we suspect this may cause problems in an AWS Lambda environment due to the way the event loop is managed there. Are there any obvious issues with this approach that I am missing? 