### PR TITLE
fix: make class extendable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,6 @@ exports = module.exports = internals.Connection = class {
 
     constructor(options = {}) {
 
-        Hoek.assert(this.constructor === internals.Connection, 'Memory cache client must be instantiated using new');
         Hoek.assert(options.maxByteSize === undefined || options.maxByteSize >= 0, 'Invalid cache maxByteSize value');
         Hoek.assert(options.allowMixedContent === undefined, 'allowMixedContent no longer supported');
         Hoek.assert(options.minCleanupIntervalMsec === undefined || options.minCleanupIntervalMsec < internals.maxTimer, 'Invalid cache minCleanupIntervalMsec value');

--- a/test/index.js
+++ b/test/index.js
@@ -380,7 +380,7 @@ describe('Memory', () => {
 
             expect(memory.get(key1).item).to.equal('myvalue1');
             expect(memory.get(key2).item).to.equal('myvalue2');
-            await Hoek.wait(140);
+            await Hoek.wait(300);
             expect(memory.cache.get(key1.segment).get(key1.id)).to.not.exist();
             expect(memory.cache.get(key2.segment).get(key2.id)).to.not.exist();
 

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,12 @@ describe('Memory', () => {
         expect(fn).to.throw(Error);
     });
 
+    it('is extendable', () => {
+
+        const fn = () => new (class extends Memory {})();
+        expect(fn).to.not.throw();
+    });
+
     it('creates a new connection', async () => {
 
         const client = new Catbox.Client(Memory);


### PR DESCRIPTION
Functions created via the class syntax are not callable. So there is no need to make the extra assertion that at the same time prevent from the class extending.

```js
const CatboxMemory = require("@hapi/catbox-memory");
class InMemoryCacheStore extends CatboxMemory {}
const store = new InMemoryCacheStore(); // => Error: Memory cache client must be instantiated using new ...
```