### PR TITLE
Support node v18 and drop node v12, make exports ESM-friendly

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/API.md
+++ b/API.md
@@ -5,7 +5,7 @@ Memory adapter for [catbox](https://github.com/hapijs/catbox).
 This adapter is not designed to share a common cache between multiple processes (e.g. in a cluster
 mode). It uses a single interval timeout to look for expired records and clean them from memory.
 
-### Options
+### `new Engine(options)`
 
 - `maxByteSize` - sets an upper limit on the number of bytes that can be stored in the
   cache. Once this limit is reached no additional items will be added to the cache

--- a/API.md
+++ b/API.md
@@ -5,7 +5,7 @@ Memory adapter for [catbox](https://github.com/hapijs/catbox).
 This adapter is not designed to share a common cache between multiple processes (e.g. in a cluster
 mode). It uses a single interval timeout to look for expired records and clean them from memory.
 
-### `new Engine(options)`
+### `new CatboxMemory.Engine(options)`
 
 - `maxByteSize` - sets an upper limit on the number of bytes that can be stored in the
   cache. Once this limit is reached no additional items will be added to the cache

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ internals.defaults = {
 };
 
 
-exports = module.exports = internals.Connection = class {
+exports.Engine = class CatboxMemoryEngine {
 
     constructor(options = {}) {
 

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/hoek": "9.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/catbox": "11.x.x",
-    "@hapi/code": "8.x.x",
+    "@hapi/catbox": "^12.0.0",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -L -t 100",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let CatboxMemory;
+
+    before(async () => {
+
+        CatboxMemory = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(CatboxMemory)).to.equal([
+            'Engine',
+            'default'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const Catbox = require('@hapi/catbox');
 const Code = require('@hapi/code');
 const Hoek = require('@hapi/hoek');
 const Lab = require('@hapi/lab');
-const Memory = require('..');
+const { Engine: Memory } = require('..');
 
 
 const internals = {};


### PR DESCRIPTION
 - Test on node v14+.
 - Update to node v18-compatible versions of hapi modules.
 - Changed export to `exports.Engine` rather than `module.exports` for more standard ESM usage.  If that seems fine, I'll apply the same convention to catbox-redis, etc.

If this looks good, this will go out as catbox-memory v6.